### PR TITLE
Fix oauth2 resource jwt keyUri property location

### DIFF
--- a/spring-cloud-cloudfoundry-web/src/main/java/org/springframework/cloud/cloudfoundry/environment/VcapServiceCredentialsEnvironmentPostProcessor.java
+++ b/spring-cloud-cloudfoundry-web/src/main/java/org/springframework/cloud/cloudfoundry/environment/VcapServiceCredentialsEnvironmentPostProcessor.java
@@ -66,7 +66,7 @@ implements EnvironmentPostProcessor, Ordered {
 		if (authDomain != null) {
 			source.put("security.oauth2.resource.userInfoUri",
 					authDomain + "/userinfo");
-			source.put("security.oauth2.resource.keyUri", authDomain + "/token_key");
+			source.put("security.oauth2.resource.jwt.keyUri", authDomain + "/token_key");
 			source.put("security.oauth2.client.accessTokenUri",
 					authDomain + "/oauth/token");
 			source.put("security.oauth2.client.userAuthorizationUri",
@@ -75,7 +75,7 @@ implements EnvironmentPostProcessor, Ordered {
 		else {
 			addProperty(source, resolver, serviceId, "resource", "userInfoUri");
 			addProperty(source, resolver, serviceId, "resource", "tokenInfoUri");
-			addProperty(source, resolver, serviceId, "resource", "keyUri");
+			addProperty(source, resolver, serviceId, "resource.jwt", "keyUri");
 			addProperty(source, resolver, serviceId, "resource", "keyValue");
 			addProperty(source, resolver, serviceId, "client", "accessTokenUri", "tokenUri");
 			addProperty(source, resolver, serviceId, "client", "userAuthorizationUri", "authorizationUri");

--- a/spring-cloud-cloudfoundry-web/src/test/java/org/springframework/cloud/cloudfoundry/environment/VcapServiceCredentialsEnvironmentPostProcessorTests.java
+++ b/spring-cloud-cloudfoundry-web/src/test/java/org/springframework/cloud/cloudfoundry/environment/VcapServiceCredentialsEnvironmentPostProcessorTests.java
@@ -100,4 +100,13 @@ public class VcapServiceCredentialsEnvironmentPostProcessorTests {
 				.resolvePlaceholders("${security.oauth2.client.accessTokenUri}"));
 	}
 
+	@Test
+	public void addJwtKeyUri() {
+		EnvironmentTestUtils.addEnvironment(this.environment,
+				"vcap.services.sso.credentials.keyUri:http://example.com");
+		this.listener.postProcessEnvironment(this.environment, new SpringApplication());
+		assertEquals("http://example.com", this.environment
+				.resolvePlaceholders("${security.oauth2.resource.jwt.keyUri}"));
+	}
+
 }


### PR DESCRIPTION
Hi guys,

I seems that `security.oauth2.resource.keyUri` property does not exist.
This fix will set `security.oauth2.resource.jwt.keyUri property` instead.

Thanks

Sebastien