### PR TITLE
URL Cleanup

### DIFF
--- a/1.1.x/spring-cloud-cloudfoundry.xml
+++ b/1.1.x/spring-cloud-cloudfoundry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud for Cloud Foundry</title>
 <date>2019-03-25</date>
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/2.0.x/spring-cloud-cloudfoundry.xml
+++ b/2.0.x/spring-cloud-cloudfoundry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud for Cloud Foundry</title>
 <date>2017-08-29</date>
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/2.1.x/spring-cloud-cloudfoundry.xml
+++ b/2.1.x/spring-cloud-cloudfoundry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud for Cloud Foundry</title>
 <date>2019-03-25</date>
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/font-awesome/font/fontawesome-webfont.svg
+++ b/font-awesome/font/fontawesome-webfont.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
-<svg xmlns="http://www.w3.org/2000/svg">
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="https://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>
 <font id="fontawesomeregular" horiz-adv-x="1536" >

--- a/spring-cloud-cloudfoundry.xml
+++ b/spring-cloud-cloudfoundry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud for Cloud Foundry</title>
 <date>2017-08-29</date>
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/spring-cloud-starter-cloudfoundry/target/checkstyle-checker.xml
+++ b/spring-cloud-starter-cloudfoundry/target/checkstyle-checker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
 		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="com.puppycrawl.tools.checkstyle.Checker">
 
 	<module name="SuppressionFilter">

--- a/target/checkstyle-checker.xml
+++ b/target/checkstyle-checker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
 		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="com.puppycrawl.tools.checkstyle.Checker">
 
 	<module name="SuppressionFilter">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.puppycrawl.com/dtds/configuration_1_3.dtd (404) with 2 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_3.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_3.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docbook.org/ns/docbook with 4 occurrences migrated to:  
  https://docbook.org/ns/docbook ([https](https://docbook.org/ns/docbook) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 4 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://www.w3.org/1999/xlink with 4 occurrences migrated to:  
  https://www.w3.org/1999/xlink ([https](https://www.w3.org/1999/xlink) result 200).
* [ ] http://www.w3.org/2000/svg with 1 occurrences migrated to:  
  https://www.w3.org/2000/svg ([https](https://www.w3.org/2000/svg) result 200).
* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 1 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).