### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -64,7 +64,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -86,13 +86,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -148,7 +148,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -161,6 +161,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/docs/src/main/asciidoc/spring-cloud-cloudfoundry.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-cloudfoundry.adoc
@@ -19,7 +19,7 @@ are configured, they default per the user's profile in Cloud Foundry.
 
 NOTE: All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/[Spring Boot user guide].
+https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/[Spring Boot user guide].
 
 This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/spring-cloud-cloudfoundry-sample/src/main/java/org/springframework/cloud/cloudfoundry/sample/CloudFoundryApplication.java
+++ b/spring-cloud-cloudfoundry-sample/src/main/java/org/springframework/cloud/cloudfoundry/sample/CloudFoundryApplication.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Bean;
 
 /**
  * This example assumes you've registered an application on
- * <A href="http://cloudfoundry.org">Cloud Foundry</A> named {@code hi-service} that
+ * <A href="https://cloudfoundry.org">Cloud Foundry</A> named {@code hi-service} that
  * responds with a String at {@code /hi/ name} . There is a sample file in the project
  * root called {@code hi-service.groovy} which you can deploy using the {@code spring} CLI
  * and the {@code cf} CLI that works appropriately for this demonstration.

--- a/spring-cloud-cloudfoundry-web/src/test/java/org/springframework/cloud/cloudfoundry/environment/VcapServiceCredentialsEnvironmentPostProcessorTests.java
+++ b/spring-cloud-cloudfoundry-web/src/test/java/org/springframework/cloud/cloudfoundry/environment/VcapServiceCredentialsEnvironmentPostProcessorTests.java
@@ -66,46 +66,46 @@ public class VcapServiceCredentialsEnvironmentPostProcessorTests {
 	@Test
 	public void addTokenUri() {
 		EnvironmentTestUtils.addEnvironment(this.environment,
-				"vcap.services.sso.credentials.accessTokenUri:http://example.com");
+				"vcap.services.sso.credentials.accessTokenUri:https://example.com");
 		this.listener.postProcessEnvironment(this.environment, new SpringApplication());
-		assertEquals("http://example.com", this.environment
+		assertEquals("https://example.com", this.environment
 				.resolvePlaceholders("${security.oauth2.client.accessTokenUri}"));
 	}
 
 	@Test
 	public void addTokenUriAuthDomain() {
 		EnvironmentTestUtils.addEnvironment(this.environment,
-				"vcap.services.sso.credentials.auth_domain:http://example.com");
+				"vcap.services.sso.credentials.auth_domain:https://example.com");
 		this.listener.postProcessEnvironment(this.environment, new SpringApplication());
-		assertEquals("http://example.com/oauth/token", this.environment
+		assertEquals("https://example.com/oauth/token", this.environment
 				.resolvePlaceholders("${security.oauth2.client.accessTokenUri}"));
 	}
 
 	@Test
 	public void addUserInfoUri() {
 		EnvironmentTestUtils.addEnvironment(this.environment,
-				"vcap.services.sso.credentials.userInfoUri:http://example.com");
+				"vcap.services.sso.credentials.userInfoUri:https://example.com");
 		this.listener.postProcessEnvironment(this.environment, new SpringApplication());
-		assertEquals("http://example.com", this.environment
+		assertEquals("https://example.com", this.environment
 				.resolvePlaceholders("${security.oauth2.resource.userInfoUri}"));
 	}
 
 	@Test
 	public void addServiceId() {
 		EnvironmentTestUtils.addEnvironment(this.environment,
-				"vcap.services.my.credentials.accessTokenUri:http://example.com",
+				"vcap.services.my.credentials.accessTokenUri:https://example.com",
 				"security.oauth2.sso.serviceId:my");
 		this.listener.postProcessEnvironment(this.environment, new SpringApplication());
-		assertEquals("http://example.com", this.environment
+		assertEquals("https://example.com", this.environment
 				.resolvePlaceholders("${security.oauth2.client.accessTokenUri}"));
 	}
 
 	@Test
 	public void addJwtKeyUri() {
 		EnvironmentTestUtils.addEnvironment(this.environment,
-				"vcap.services.sso.credentials.keyUri:http://example.com");
+				"vcap.services.sso.credentials.keyUri:https://example.com");
 		this.listener.postProcessEnvironment(this.environment, new SpringApplication());
-		assertEquals("http://example.com", this.environment
+		assertEquals("https://example.com", this.environment
 				.resolvePlaceholders("${security.oauth2.resource.jwt.keyUri}"));
 	}
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://example.com/oauth/token (404) with 1 occurrences migrated to:  
  https://example.com/oauth/token ([https](https://example.com/oauth/token) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://example.com with 9 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://cloudfoundry.org with 1 occurrences migrated to:  
  https://cloudfoundry.org ([https](https://cloudfoundry.org) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).