### PR TITLE
update usage of discovery client in reactive non-blocking context - Fixes gh-57

### DIFF
--- a/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/CloudFoundryAppServiceDiscoveryClient.java
+++ b/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/CloudFoundryAppServiceDiscoveryClient.java
@@ -33,6 +33,7 @@ import org.springframework.cloud.cloudfoundry.CloudFoundryService;
  * Discovery.
  *
  * @author Toshiaki Maki
+ * @author Srinivasa Vasu
  * @see <a href="https://github.com/cloudfoundry/cf-app-sd-release">CF App Service
  * Discovery Release</a>
  * @see <a href=
@@ -64,6 +65,7 @@ public class CloudFoundryAppServiceDiscoveryClient extends CloudFoundryDiscovery
 					InstanceDetail instanceDetail = tuple.getT2();
 					String applicationId = applicationDetail.getId();
 					String applicationIndex = instanceDetail.getIndex();
+					String instanceId = applicationId + "." + applicationIndex;
 					String name = applicationDetail.getName();
 					String url = applicationDetail.getUrls().stream()
 							.filter(this::isInternalDomain).findFirst()
@@ -71,9 +73,9 @@ public class CloudFoundryAppServiceDiscoveryClient extends CloudFoundryDiscovery
 					HashMap<String, String> metadata = new HashMap<>();
 					metadata.put("applicationId", applicationId);
 					metadata.put("instanceId", applicationIndex);
-					return (ServiceInstance) new DefaultServiceInstance(name, url, 8080,
-							false, metadata);
-				}).collectList().block();
+					return (ServiceInstance) new DefaultServiceInstance(instanceId, name,
+							url, 8080, false, metadata);
+				}).collectList().toFuture().join();
 	}
 
 	private boolean isInternalDomain(String url) {

--- a/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/CloudFoundryDiscoveryClient.java
+++ b/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/CloudFoundryDiscoveryClient.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.cloudfoundry.CloudFoundryService;
  * @author Dave Syer
  * @author Olga Maciaszek-Sharma
  * @author Tim Ysewyn
+ * @author Srinivasa Vasu
  */
 public class CloudFoundryDiscoveryClient implements DiscoveryClient {
 
@@ -83,7 +84,7 @@ public class CloudFoundryDiscoveryClient implements DiscoveryClient {
 
 			return (ServiceInstance) new DefaultServiceInstance(instanceId, name, url, 80,
 					secure, metadata);
-		}).collectList().blockOptional().orElse(new ArrayList<>());
+		}).collectList().toFuture().join();
 	}
 
 	@Override

--- a/spring-cloud-cloudfoundry-discovery/src/test/java/org/springframework/cloud/cloudfoundry/discovery/CloudFoundryAppServiceDiscoveryClientTest.java
+++ b/spring-cloud-cloudfoundry-discovery/src/test/java/org/springframework/cloud/cloudfoundry/discovery/CloudFoundryAppServiceDiscoveryClientTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.mock;
 
 /**
  * @author Toshiaki Maki
+ * @author Srinivasa Vasu
  */
 public class CloudFoundryAppServiceDiscoveryClientTest {
 
@@ -58,20 +59,22 @@ public class CloudFoundryAppServiceDiscoveryClientTest {
 	@Test
 	public void getInstancesOneInstance() {
 		String serviceId = "billing";
-		ApplicationDetail applicationDetail = ApplicationDetail.builder().id("billing1")
-				.name("billing").instances(1).memoryLimit(1024).stack("cflinux2")
+		ApplicationDetail applicationDetail = ApplicationDetail.builder().id(serviceId)
+				.name(serviceId).instances(1).memoryLimit(1024).stack("cflinux2")
 				.diskQuota(1024).requestedState("Running").runningInstances(1)
-				.url("billing.apps.example.com", "billing.apps.internal").build();
+				.url(serviceId + ".apps.example.com", serviceId + ".apps.internal")
+				.build();
 		given(this.cloudFoundryService.getApplicationInstances(serviceId))
 				.willReturn(Flux.just(Tuples.of(applicationDetail,
 						InstanceDetail.builder().index("0").build())));
 		List<ServiceInstance> instances = this.discoveryClient.getInstances(serviceId);
 
 		assertThat(instances).hasSize(1);
-		assertThat(instances.get(0)).isEqualTo(new DefaultServiceInstance(serviceId,
-				"0.billing.apps.internal", 8080, false, new HashMap<String, String>() {
+		assertThat(instances.get(0)).isEqualTo(new DefaultServiceInstance(
+				serviceId + ".0", serviceId, "0.billing.apps.internal", 8080, false,
+				new HashMap<String, String>() {
 					{
-						put("applicationId", "billing1");
+						put("applicationId", serviceId);
 						put("instanceId", "0");
 					}
 				}));
@@ -80,10 +83,11 @@ public class CloudFoundryAppServiceDiscoveryClientTest {
 	@Test
 	public void getInstancesThreeInstance() {
 		String serviceId = "billing";
-		ApplicationDetail applicationDetail = ApplicationDetail.builder().id("billing-id")
-				.name("billing").instances(3).memoryLimit(1024).stack("cflinux2")
+		ApplicationDetail applicationDetail = ApplicationDetail.builder().id(serviceId)
+				.name(serviceId).instances(3).memoryLimit(1024).stack("cflinux2")
 				.diskQuota(1024).requestedState("Running").runningInstances(3)
-				.url("billing.apps.example.com", "billing.apps.internal").build();
+				.url(serviceId + ".apps.example.com", serviceId + ".apps.internal")
+				.build();
 		given(this.cloudFoundryService.getApplicationInstances(serviceId))
 				.willReturn(Flux.just(
 						Tuples.of(applicationDetail,
@@ -95,24 +99,27 @@ public class CloudFoundryAppServiceDiscoveryClientTest {
 		List<ServiceInstance> instances = this.discoveryClient.getInstances(serviceId);
 
 		assertThat(instances).hasSize(3);
-		assertThat(instances.get(0)).isEqualTo(new DefaultServiceInstance(serviceId,
-				"0.billing.apps.internal", 8080, false, new HashMap<String, String>() {
+		assertThat(instances.get(0)).isEqualTo(new DefaultServiceInstance(
+				serviceId + ".0", serviceId, "0." + serviceId + ".apps.internal", 8080,
+				false, new HashMap<String, String>() {
 					{
-						put("applicationId", "billing-id");
+						put("applicationId", serviceId);
 						put("instanceId", "0");
 					}
 				}));
-		assertThat(instances.get(1)).isEqualTo(new DefaultServiceInstance(serviceId,
-				"1.billing.apps.internal", 8080, false, new HashMap<String, String>() {
+		assertThat(instances.get(1)).isEqualTo(new DefaultServiceInstance(
+				serviceId + ".1", serviceId, "1." + serviceId + ".apps.internal", 8080,
+				false, new HashMap<String, String>() {
 					{
-						put("applicationId", "billing-id");
+						put("applicationId", serviceId);
 						put("instanceId", "1");
 					}
 				}));
-		assertThat(instances.get(2)).isEqualTo(new DefaultServiceInstance(serviceId,
-				"2.billing.apps.internal", 8080, false, new HashMap<String, String>() {
+		assertThat(instances.get(2)).isEqualTo(new DefaultServiceInstance(
+				serviceId + ".2", serviceId, "2." + serviceId + ".apps.internal", 8080,
+				false, new HashMap<String, String>() {
 					{
-						put("applicationId", "billing-id");
+						put("applicationId", serviceId);
 						put("instanceId", "2");
 					}
 				}));
@@ -121,10 +128,10 @@ public class CloudFoundryAppServiceDiscoveryClientTest {
 	@Test
 	public void getInstancesEmpty() {
 		String serviceId = "billing";
-		ApplicationDetail applicationDetail = ApplicationDetail.builder().id("billing1")
-				.name("billing").instances(1).memoryLimit(1024).stack("cflinux2")
+		ApplicationDetail applicationDetail = ApplicationDetail.builder().id(serviceId)
+				.name(serviceId).instances(1).memoryLimit(1024).stack("cflinux2")
 				.diskQuota(1024).requestedState("Running").runningInstances(1)
-				.url("billing.apps.example.com").build();
+				.url(serviceId + ".apps.example.com").build();
 		given(this.cloudFoundryService.getApplicationInstances(serviceId))
 				.willReturn(Flux.just(Tuples.of(applicationDetail,
 						InstanceDetail.builder().index("0").build())));


### PR DESCRIPTION
Fix for #57 
* update usage of discovery client in non-blocking reactive context
* update test cases