### PR TITLE
update cf discovery defaults in service discovery

### DIFF
--- a/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/reactive/CloudFoundryAppServiceReactiveDiscoveryClient.java
+++ b/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/reactive/CloudFoundryAppServiceReactiveDiscoveryClient.java
@@ -62,7 +62,12 @@ public class CloudFoundryAppServiceReactiveDiscoveryClient
 	}
 
 	protected String getRouteURL(List<String> urls) {
-		return urls.stream().filter(this::isInternalDomain).findFirst().orElse("");
+		for (String url : urls) {
+			if (isInternalDomain(url)) {
+				return url;
+			}
+		}
+		return "";
 	}
 
 }

--- a/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/reactive/CloudFoundryAppServiceReactiveDiscoveryClient.java
+++ b/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/reactive/CloudFoundryAppServiceReactiveDiscoveryClient.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.cloudfoundry.discovery.reactive;
 
+import java.util.List;
+
 import org.cloudfoundry.operations.CloudFoundryOperations;
 import reactor.core.publisher.Flux;
 
@@ -36,8 +38,6 @@ import org.springframework.cloud.cloudfoundry.discovery.CloudFoundryDiscoveryPro
  */
 public class CloudFoundryAppServiceReactiveDiscoveryClient
 		extends CloudFoundryNativeReactiveDiscoveryClient {
-
-	private static final String INTERNAL_DOMAIN = "apps.internal";
 
 	private final CloudFoundryService cloudFoundryService;
 
@@ -61,8 +61,8 @@ public class CloudFoundryAppServiceReactiveDiscoveryClient
 				.map(this::mapApplicationInstanceToServiceInstance);
 	}
 
-	private boolean isInternalDomain(String url) {
-		return url != null && url.endsWith(INTERNAL_DOMAIN);
+	protected String getRouteURL(List<String> urls) {
+		return urls.stream().filter(this::isInternalDomain).findFirst().orElse("");
 	}
 
 }

--- a/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/reactive/CloudFoundryReactiveDiscoveryClientConfiguration.java
+++ b/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/reactive/CloudFoundryReactiveDiscoveryClientConfiguration.java
@@ -103,9 +103,7 @@ public class CloudFoundryReactiveDiscoveryClientConfiguration {
 					ObjectProvider<ServiceIdToHostnameConverter> provider,
 					CloudFoundryDiscoveryProperties properties) {
 				ServiceIdToHostnameConverter converter = provider.getIfAvailable();
-				return converter == null
-						? new SimpleDnsBasedReactiveDiscoveryClient(properties)
-						: new SimpleDnsBasedReactiveDiscoveryClient(converter);
+				return new SimpleDnsBasedReactiveDiscoveryClient(properties, converter);
 			}
 
 			@Bean

--- a/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/reactive/SimpleDnsBasedReactiveDiscoveryClient.java
+++ b/spring-cloud-cloudfoundry-discovery/src/main/java/org/springframework/cloud/cloudfoundry/discovery/reactive/SimpleDnsBasedReactiveDiscoveryClient.java
@@ -50,6 +50,18 @@ public class SimpleDnsBasedReactiveDiscoveryClient implements ReactiveDiscoveryC
 	private final CloudFoundryDiscoveryProperties properties;
 
 	public SimpleDnsBasedReactiveDiscoveryClient(
+			ServiceIdToHostnameConverter serviceIdToHostnameConverter) {
+		this.serviceIdToHostnameConverter = serviceIdToHostnameConverter;
+		// added for backward compatibility
+		this.properties = new CloudFoundryDiscoveryProperties();
+	}
+
+	public SimpleDnsBasedReactiveDiscoveryClient(
+			CloudFoundryDiscoveryProperties properties) {
+		this(serviceId -> serviceId + "." + properties.getInternalDomain());
+	}
+
+	public SimpleDnsBasedReactiveDiscoveryClient(
 			CloudFoundryDiscoveryProperties properties,
 			ServiceIdToHostnameConverter serviceIdToHostnameConverter) {
 		this.properties = properties;

--- a/spring-cloud-cloudfoundry-discovery/src/test/java/org/springframework/cloud/cloudfoundry/discovery/reactive/CloudFoundryAppServiceReactiveDiscoveryClientTests.java
+++ b/spring-cloud-cloudfoundry-discovery/src/test/java/org/springframework/cloud/cloudfoundry/discovery/reactive/CloudFoundryAppServiceReactiveDiscoveryClientTests.java
@@ -32,6 +32,7 @@ import reactor.util.function.Tuples;
 
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.cloudfoundry.CloudFoundryService;
+import org.springframework.cloud.cloudfoundry.discovery.CloudFoundryDiscoveryProperties;
 
 import static org.mockito.Mockito.when;
 
@@ -44,11 +45,15 @@ class CloudFoundryAppServiceReactiveDiscoveryClientTests {
 	@Mock
 	private CloudFoundryService svc;
 
+	@Mock
+	private CloudFoundryDiscoveryProperties properties;
+
 	@InjectMocks
 	private CloudFoundryAppServiceReactiveDiscoveryClient client;
 
 	@Test
 	public void shouldReturnFluxOfServiceInstances() {
+		when(properties.getInternalDomain()).thenReturn("apps.internal");
 		ApplicationDetail appDetail1 = ApplicationDetail.builder()
 				.id(UUID.randomUUID().toString()).stack("stack").instances(1)
 				.memoryLimit(1024).requestedState("requestedState").diskQuota(1024)


### PR DESCRIPTION
- updated reactive discovery classes to populate `spring.cloud.cloudfoundry.discovery.default-server-port` and `spring.cloud.cloudfoundry.discovery.internal-domain` if passed externally.
- updated internal domain url to use 8080 and external route url to 80 as the default if the external input is not passed
- removed protocol check as cf application endpoint url is not sending the protocol info in the response.
- updated the appropriate test case 