### PR TITLE
Upgrade cf-java-client dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	</parent>
 
 	<properties>
-		<cf-java-client.version>3.9.0.RELEASE</cf-java-client.version>
+		<cf-java-client.version>4.9.0.RELEASE</cf-java-client.version>
 		<bintray.package>cloudfoundry</bintray.package>
 		<main.basedir>${basedir}</main.basedir>
 		<spring-cloud-commons.version>3.0.0-SNAPSHOT</spring-cloud-commons.version>

--- a/spring-cloud-cloudfoundry-commons/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryClientAutoConfigurationTest.java
+++ b/spring-cloud-cloudfoundry-commons/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryClientAutoConfigurationTest.java
@@ -26,7 +26,6 @@ import org.cloudfoundry.reactor.tokenprovider.PasswordGrantTokenProvider;
 import org.cloudfoundry.reactor.uaa.ReactorUaaClient;
 import org.cloudfoundry.routing.RoutingClient;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -58,7 +57,7 @@ public class CloudFoundryClientAutoConfigurationTest {
 	}
 
 	@Test
-	@Ignore // see https://github.com/spring-cloud/spring-cloud-cloudfoundry/issues/65
+	// @Ignore // see https://github.com/spring-cloud/spring-cloud-cloudfoundry/issues/65
 	public void autoConfiguresBeansWithAllProperties() {
 		this.contextRunner.withPropertyValues("spring.cloud.cloudfoundry.username=user",
 				"spring.cloud.cloudfoundry.password=secret",
@@ -74,7 +73,7 @@ public class CloudFoundryClientAutoConfigurationTest {
 	}
 
 	@Test
-	@Ignore // see https://github.com/spring-cloud/spring-cloud-cloudfoundry/issues/65
+	// @Ignore // see https://github.com/spring-cloud/spring-cloud-cloudfoundry/issues/65
 	public void autoConfiguresBeansWithMinimalProperties() {
 		this.contextRunner.withPropertyValues("spring.cloud.cloudfoundry.username=user",
 				"spring.cloud.cloudfoundry.password=secret").run((context) -> {

--- a/spring-cloud-cloudfoundry-commons/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryClientAutoConfigurationTest.java
+++ b/spring-cloud-cloudfoundry-commons/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryClientAutoConfigurationTest.java
@@ -57,7 +57,6 @@ public class CloudFoundryClientAutoConfigurationTest {
 	}
 
 	@Test
-	// @Ignore // see https://github.com/spring-cloud/spring-cloud-cloudfoundry/issues/65
 	public void autoConfiguresBeansWithAllProperties() {
 		this.contextRunner.withPropertyValues("spring.cloud.cloudfoundry.username=user",
 				"spring.cloud.cloudfoundry.password=secret",
@@ -73,7 +72,6 @@ public class CloudFoundryClientAutoConfigurationTest {
 	}
 
 	@Test
-	// @Ignore // see https://github.com/spring-cloud/spring-cloud-cloudfoundry/issues/65
 	public void autoConfiguresBeansWithMinimalProperties() {
 		this.contextRunner.withPropertyValues("spring.cloud.cloudfoundry.username=user",
 				"spring.cloud.cloudfoundry.password=secret").run((context) -> {

--- a/spring-cloud-cloudfoundry-discovery/src/test/java/org/springframework/cloud/cloudfoundry/discovery/CloudFoundryAppServiceDiscoveryClientTest.java
+++ b/spring-cloud-cloudfoundry-discovery/src/test/java/org/springframework/cloud/cloudfoundry/discovery/CloudFoundryAppServiceDiscoveryClientTest.java
@@ -61,7 +61,7 @@ public class CloudFoundryAppServiceDiscoveryClientTest {
 		ApplicationDetail applicationDetail = ApplicationDetail.builder().id("billing1")
 				.name("billing").instances(1).memoryLimit(1024).stack("cflinux2")
 				.diskQuota(1024).requestedState("Running").runningInstances(1)
-				.url("billing.apps.example.com", "billing.apps.internal").build();
+				.urls("billing.apps.example.com", "billing.apps.internal").build();
 		given(this.cloudFoundryService.getApplicationInstances(serviceId))
 				.willReturn(Flux.just(Tuples.of(applicationDetail,
 						InstanceDetail.builder().index("0").build())));
@@ -83,7 +83,7 @@ public class CloudFoundryAppServiceDiscoveryClientTest {
 		ApplicationDetail applicationDetail = ApplicationDetail.builder().id("billing-id")
 				.name("billing").instances(3).memoryLimit(1024).stack("cflinux2")
 				.diskQuota(1024).requestedState("Running").runningInstances(3)
-				.url("billing.apps.example.com", "billing.apps.internal").build();
+				.urls("billing.apps.example.com", "billing.apps.internal").build();
 		given(this.cloudFoundryService.getApplicationInstances(serviceId))
 				.willReturn(Flux.just(
 						Tuples.of(applicationDetail,


### PR DESCRIPTION
Bump `cf-java-client.version` from `3.9.0.RELEASE` to `4.9.0.RELEASE` and fix failing tests after upgrade.
Changes to fix the test case in `CloudFoundryAppServiceDiscoveryClientTest` and uncomment tests in `CloudFoundryClientAutoConfigurationTest`.

Closes gh-65.