### PR TITLE
Removed duplicate dependency from spring-cloud-cloudfoundry-dependencies

### DIFF
--- a/spring-cloud-cloudfoundry-dependencies/pom.xml
+++ b/spring-cloud-cloudfoundry-dependencies/pom.xml
@@ -33,11 +33,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-cloudfoundry-commons</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-cloudfoundry</artifactId>
 				<version>${project.version}</version>
 			</dependency>


### PR DESCRIPTION
Really minor detail but I noticed that org.springframework.cloud:spring-cloud-cloudfoundry-commons was duplicated in the dependencyManagement section of spring-cloud-cloudfoundry-dependencies. It isn't hurting anything but it isn't necessary either.